### PR TITLE
Synchronize graphql-core support with graphene

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-graphene = "~=3.1"
+graphene = "~=3.0b8"
 starlette = ">=0.14.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-graphene = "~=3.0b8"
+graphene = ">=3.0b6"
+graphql-core = ">=3.1,<3.3"
 starlette = ">=0.14.1"
 
 [tool.poetry.dev-dependencies]

--- a/starlette_graphene3.py
+++ b/starlette_graphene3.py
@@ -21,7 +21,6 @@ from graphql import (
     ExecutionContext,
     ExecutionResult,
     GraphQLError,
-    GraphQLFormattedError,
     Middleware,
     OperationType,
     execute,
@@ -30,7 +29,6 @@ from graphql import (
     subscribe,
     validate,
 )
-from graphql.error.graphql_error import format_error
 from graphql.language.ast import DocumentNode, OperationDefinitionNode
 from graphql.utilities import get_operation_ast
 from starlette.background import BackgroundTasks
@@ -39,6 +37,15 @@ from starlette.requests import HTTPConnection, Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
+
+try:
+    # graphql-core==3.2.*
+    from graphql import GraphQLFormattedError
+    from graphql.error.graphql_error import format_error
+except ImportError:
+    # graphql-core==3.1.*
+    from graphql import format_error
+    GraphQLFormattedError = Dict[str, Any]
 
 GQL_CONNECTION_ACK = "connection_ack"
 GQL_CONNECTION_ERROR = "connection_error"


### PR DESCRIPTION
ref https://github.com/ciscorn/starlette-graphene3/pull/29#discussion_r885107048

- revert to `graphene = ">=3.0b6"`
- add `graphql-core` pins explicitly supported by this library